### PR TITLE
remove hardcoded baudrate in examples

### DIFF
--- a/SDM_Config_User.h
+++ b/SDM_Config_User.h
@@ -40,7 +40,7 @@
     #define SDM_TX_PIN                        15
   #else
     #define SDM_RX_PIN                        10
-    #define SDM_TX_PIN                        11  
+    #define SDM_TX_PIN                        11
   #endif
 #endif
 
@@ -49,7 +49,7 @@
 /*
 *  define user DERE_PIN for control MAX485 DE/RE lines (connect DE & /RE together to this pin)
 */
-//#define DERE_PIN                            NOT_A_PIN                           
+//#define DERE_PIN                            NOT_A_PIN
 
 //------------------------------------------------------------------------------
 

--- a/examples/sdm_live_page_esp32_hwserial/sdm_live_page_esp32_hwserial.ino
+++ b/examples/sdm_live_page_esp32_hwserial/sdm_live_page_esp32_hwserial.ino
@@ -40,7 +40,7 @@
 //------------------------------------------------------------------------------
 AsyncWebServer server(80);
 
-SDM sdm(Serial, 9600, NOT_A_PIN, SERIAL_8N1, 3, 1);                             //esp32 default pins for Serial0 => RX pin 3, TX pin 1
+SDM sdm(Serial, SDM_UART_BAUD, NOT_A_PIN, SERIAL_8N1, 3, 1);                             //esp32 default pins for Serial0 => RX pin 3, TX pin 1
 
 //------------------------------------------------------------------------------
 String devicename = "PWRMETER";
@@ -91,12 +91,12 @@ String getUptimeString() {
 
   char buffer[20];
   sprintf(buffer, "%4u days %02d:%02d:%02d", days, hours, minutes, seconds);
-  return buffer;  
+  return buffer;
 }
 //------------------------------------------------------------------------------
 void xmlrequest(AsyncWebServerRequest *request) {
   String XML = F("<?xml version='1.0'?><xml>");
-  for (int i = 0; i < NBREG; i++) { 
+  for (int i = 0; i < NBREG; i++) {
     XML += "<response" + (String)i + ">";
     XML += String(sdmarr[i].regvalarr,2);
     XML += "</response" + (String)i + ">";
@@ -121,7 +121,7 @@ void xmlrequest(AsyncWebServerRequest *request) {
 }
 //------------------------------------------------------------------------------
 void indexrequest(AsyncWebServerRequest *request) {
-  request->send_P(200, "text/html", index_page); 
+  request->send_P(200, "text/html", index_page);
 }
 //------------------------------------------------------------------------------
 void ledOn() {

--- a/examples/sdm_live_page_esp8266_hwserial/sdm_live_page_esp8266_hwserial.ino
+++ b/examples/sdm_live_page_esp8266_hwserial/sdm_live_page_esp8266_hwserial.ino
@@ -38,7 +38,7 @@ TX SSer/HSer swap D8|15                            |GND
 //------------------------------------------------------------------------------
 AsyncWebServer server(80);
 
-SDM sdm(Serial, 9600, NOT_A_PIN, SERIAL_8N1, false);                            //HARDWARE SERIAL
+SDM sdm(Serial, SDM_UART_BAUD, NOT_A_PIN, SERIAL_8N1, false);                            //HARDWARE SERIAL
 
 //------------------------------------------------------------------------------
 String devicename = "PWRMETER";
@@ -71,7 +71,7 @@ volatile sdm_struct sdmarr[NBREG] = {
 //------------------------------------------------------------------------------
 void xmlrequest(AsyncWebServerRequest *request) {
   String XML = F("<?xml version='1.0'?><xml>");
-  for (int i = 0; i < NBREG; i++) { 
+  for (int i = 0; i < NBREG; i++) {
     XML += "<response" + (String)i + ">";
     XML += String(sdmarr[i].regvalarr,2);
     XML += "</response" + (String)i + ">";
@@ -87,7 +87,7 @@ void xmlrequest(AsyncWebServerRequest *request) {
 }
 //------------------------------------------------------------------------------
 void indexrequest(AsyncWebServerRequest *request) {
-  request->send_P(200, "text/html", index_page); 
+  request->send_P(200, "text/html", index_page);
 }
 //------------------------------------------------------------------------------
 void ledOn() {

--- a/examples/sdm_simple/sdm_simple.ino
+++ b/examples/sdm_simple/sdm_simple.ino
@@ -14,7 +14,7 @@ TX SSer/HSer swap D8|15                            |GND
                        |___________________________|
 */
 
-//REMEMBER! uncomment #define USE_HARDWARESERIAL 
+//REMEMBER! uncomment #define USE_HARDWARESERIAL
 //in SDM_Config_User.h file if you want to use hardware uart
 
 #include <SDM.h>                                                                //import SDM library
@@ -22,11 +22,11 @@ TX SSer/HSer swap D8|15                            |GND
 #if defined ( USE_HARDWARESERIAL )                                              //for HWSERIAL
 
 #if defined ( ESP8266 )                                                         //for ESP8266
-SDM sdm(Serial1, 4800, NOT_A_PIN, SERIAL_8N1);                                  //config SDM
+SDM sdm(Serial1, SDM_UART_BAUD, NOT_A_PIN, SERIAL_8N1);                                  //config SDM
 #elif defined ( ESP32 )                                                         //for ESP32
-SDM sdm(Serial1, 4800, NOT_A_PIN, SERIAL_8N1, SDM_RX_PIN, SDM_TX_PIN);          //config SDM
+SDM sdm(Serial1, SDM_UART_BAUD, NOT_A_PIN, SERIAL_8N1, SDM_RX_PIN, SDM_TX_PIN);          //config SDM
 #else                                                                           //for AVR
-SDM sdm(Serial1, 4800, NOT_A_PIN);                                              //config SDM on Serial1 (if available!)
+SDM sdm(Serial1, SDM_UART_BAUD, NOT_A_PIN);                                              //config SDM on Serial1 (if available!)
 #endif
 
 #else                                                                           //for SWSERIAL
@@ -34,10 +34,10 @@ SDM sdm(Serial1, 4800, NOT_A_PIN);                                              
 #include <SoftwareSerial.h>                                                     //import SoftwareSerial library
 #if defined ( ESP8266 ) || defined ( ESP32 )                                    //for ESP
 SoftwareSerial swSerSDM;                                                        //config SoftwareSerial
-SDM sdm(swSerSDM, 4800, NOT_A_PIN, SWSERIAL_8N1, SDM_RX_PIN, SDM_TX_PIN);       //config SDM
+SDM sdm(swSerSDM, SDM_UART_BAUD, NOT_A_PIN, SWSERIAL_8N1, SDM_RX_PIN, SDM_TX_PIN);       //config SDM
 #else                                                                           //for AVR
 SoftwareSerial swSerSDM(SDM_RX_PIN, SDM_TX_PIN);                                //config SoftwareSerial
-SDM sdm(swSerSDM, 4800, NOT_A_PIN);                                             //config SDM
+SDM sdm(swSerSDM, SDM_UART_BAUD, NOT_A_PIN);                                             //config SDM
 #endif
 
 #endif
@@ -57,7 +57,7 @@ void loop() {
   Serial.println("V");
 
   Serial.print("Current:   ");
-  Serial.print(sdm.readVal(SDM_PHASE_1_CURRENT), 2);                            //display current  
+  Serial.print(sdm.readVal(SDM_PHASE_1_CURRENT), 2);                            //display current
   Serial.println("A");
 
   Serial.print("Power:     ");
@@ -66,7 +66,7 @@ void loop() {
 
   Serial.print("Frequency: ");
   Serial.print(sdm.readVal(SDM_FREQUENCY), 2);                                  //display frequency
-  Serial.println("Hz");   
+  Serial.println("Hz");
 
   delay(1000);                                                                  //wait a while before next loop
 }


### PR DESCRIPTION
I spend a few hours to get the examples working and finally I noticed that even if I setup the baud rate value in `SDM_Config_User.h` file then it is hardcoded in examples.

Lets avoid the mistake in the future in other users :)