### PR TITLE
esp32 hardware serial per default

### DIFF
--- a/SDM.cpp
+++ b/SDM.cpp
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 #include "SDM.h"
 //------------------------------------------------------------------------------
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
 #if defined ( ESP8266 )
 SDM::SDM(HardwareSerial& serial, long baud, int dere_pin, int config, bool swapuart) : sdmSer(serial) {
   this->_baud = baud;
@@ -30,7 +30,7 @@ SDM::SDM(HardwareSerial& serial, long baud, int dere_pin, int config) : sdmSer(s
 }
 #endif
 #else
-#if defined ( ESP8266 ) || defined ( ESP32 )
+#if defined ( ESP8266 )
 SDM::SDM(SoftwareSerial& serial, long baud, int dere_pin, int config, int8_t rx_pin, int8_t tx_pin) : sdmSer(serial) {
   this->_baud = baud;
   this->_dere_pin = dere_pin;
@@ -50,7 +50,7 @@ SDM::~SDM() {
 }
 
 void SDM::begin(void) {
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
 #if defined ( ESP8266 )
   sdmSer.begin(_baud, (SerialConfig)_config);
 #elif defined ( ESP32 )
@@ -59,7 +59,7 @@ void SDM::begin(void) {
   sdmSer.begin(_baud, _config);
 #endif
 #else
-#if defined ( ESP8266 ) || defined ( ESP32 )
+#if defined ( ESP8266 )
   sdmSer.begin(_baud, (SoftwareSerialConfig)_config, _rx_pin, _tx_pin);
 #else
   sdmSer.begin(_baud);
@@ -91,7 +91,7 @@ float SDM::readVal(uint16_t reg, uint8_t node) {
   sdmarr[6] = lowByte(temp);
   sdmarr[7] = highByte(temp);
 
-#if !defined ( USE_HARDWARESERIAL )
+#if !defined ( USE_HARDWARESERIAL ) && !defined ( ESP32 )
   sdmSer.listen();                                                              //enable softserial rx interrupt
 #endif
 
@@ -158,7 +158,7 @@ float SDM::readVal(uint16_t reg, uint8_t node) {
     ++readingsuccesscount;
   }
 
-#if !defined ( USE_HARDWARESERIAL )
+#if !defined ( USE_HARDWARESERIAL ) && !defined ( ESP32 )
   sdmSer.stopListening();                                                       //disable softserial rx interrupt
 #endif
 

--- a/SDM.h
+++ b/SDM.h
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 #include <Arduino.h>
 #include <SDM_Config_User.h>
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
   #include <HardwareSerial.h>
 #else
   #include <SoftwareSerial.h>
@@ -25,7 +25,7 @@
   #define DERE_PIN                                    NOT_A_PIN                 //  default digital pin for control MAX485 DE/RE lines (connect DE & /RE together to this pin)
 #endif
 
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
 
   #if !defined ( SDM_UART_CONFIG )
     #define SDM_UART_CONFIG                           SERIAL_8N1                //  default hardware uart config
@@ -46,7 +46,7 @@
 
 #else
 
-  #if defined ( ESP8266 ) || defined ( ESP32 )
+  #if defined ( ESP8266 )
     #if !defined ( SDM_UART_CONFIG )
       #define SDM_UART_CONFIG                         SWSERIAL_8N1              //  default softwareware uart config for esp8266/esp32
     #endif
@@ -233,7 +233,7 @@
 
 class SDM {
   public:
-#if defined ( USE_HARDWARESERIAL )                                              //  hardware serial
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )                         //  hardware serial
   #if defined ( ESP8266 )                                                       //  on esp8266
     SDM(HardwareSerial& serial, long baud = SDM_UART_BAUD, int dere_pin = DERE_PIN, int config = SDM_UART_CONFIG, bool swapuart = SWAPHWSERIAL);
   #elif defined ( ESP32 )                                                       //  on esp32
@@ -242,7 +242,7 @@ class SDM {
     SDM(HardwareSerial& serial, long baud = SDM_UART_BAUD, int dere_pin = DERE_PIN, int config = SDM_UART_CONFIG);
   #endif
 #else                                                                           //  software serial
-  #if defined ( ESP8266 ) || defined ( ESP32 )                                  //  on esp8266/esp32
+  #if defined ( ESP8266 )                                                       //  on esp8266
     SDM(SoftwareSerial& serial, long baud = SDM_UART_BAUD, int dere_pin = DERE_PIN, int config = SDM_UART_CONFIG, int8_t rx_pin = SDM_RX_PIN, int8_t tx_pin = SDM_TX_PIN);
   #else                                                                         //  on avr
     SDM(SoftwareSerial& serial, long baud = SDM_UART_BAUD, int dere_pin = DERE_PIN);
@@ -264,13 +264,13 @@ class SDM {
     uint16_t getMsTimeout();                                                    //  get current value of RESPONSE_TIMEOUT (ms)
 
   private:
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
     HardwareSerial& sdmSer;
 #else
     SoftwareSerial& sdmSer;
 #endif
 
-#if defined ( USE_HARDWARESERIAL )
+#if defined ( USE_HARDWARESERIAL ) || defined ( ESP32 )
     int _config = SDM_UART_CONFIG;
   #if defined ( ESP8266 )
     bool _swapuart = SWAPHWSERIAL;
@@ -279,7 +279,7 @@ class SDM {
     int8_t _tx_pin = -1;
   #endif
 #else
-  #if defined ( ESP8266 ) || defined ( ESP32 )
+  #if defined ( ESP8266 )
     int _config = SDM_UART_CONFIG;
   #endif
     int8_t _rx_pin = -1;

--- a/examples/sdm_live_page_esp32_hwserial/sdm_live_page_esp32_hwserial.ino
+++ b/examples/sdm_live_page_esp32_hwserial/sdm_live_page_esp32_hwserial.ino
@@ -34,9 +34,6 @@
 
 #include "index_page.h"
 
-#if !defined ( USE_HARDWARESERIAL )
-  #error "This example works with Hardware Serial on esp32, please uncomment #define USE_HARDWARESERIAL in SDM_Config_User.h"
-#endif
 //------------------------------------------------------------------------------
 AsyncWebServer server(80);
 


### PR DESCRIPTION
resolves #73 

But, now I've found a SW serial for ESP32, but it is not in esp32 core, it's external library:
https://github.com/plerup/espsoftwareserial
I think, now it makes more sense to integrate espsoftserial for esp32 and leave sw serial as default and hw serial as an option...

@reaper7 what do you think about it?
