### PR TITLE
update for new EspSoftwareSerial version 8.01

### DIFF
--- a/SDM.cpp
+++ b/SDM.cpp
@@ -60,7 +60,7 @@ void SDM::begin(void) {
 #endif
 #else
 #if defined ( ESP8266 ) || defined ( ESP32 )
-  sdmSer.begin(_baud, (SoftwareSerialConfig)_config, _rx_pin, _tx_pin);
+  sdmSer.begin(_baud, (EspSoftwareSerial::Config)_config, _rx_pin, _tx_pin);
 #else
   sdmSer.begin(_baud);
 #endif


### PR DESCRIPTION
The refactoring of EspSoftwareSerial (see https://github.com/plerup/espsoftwareserial/commit/3c9c586a993972c9526275f5ecd7d6c74a7c8958) breaks SDM.cpp at line 63.
Without this change, EspSoftwareSerial versions >= 8.0.1 will not work!
Be aware: with this change, versions <8.0.1 will not work!